### PR TITLE
Add sniff and tests for No CDN URL

### DIFF
--- a/WordPress/Sniffs/Theme/NoCDNSniff.php
+++ b/WordPress/Sniffs/Theme/NoCDNSniff.php
@@ -25,31 +25,37 @@ class WordPress_Sniffs_Theme_NoCDNSniff extends WordPress_AbstractFunctionParame
 	 *
 	 * @var string
 	 */
-	protected $group_name = 'wp_enqueue_style';
+	protected $group_name = 'no_cdn';
 
 	/**
-	 * Array of functions and parameters.
+	 * Array of functions with positions.
+	 *
+	 * The number represents the position in the function call
+	 * passed variables, here the capability is to be listed.
 	 *
 	 * @since 0.xx.0
 	 *
 	 * @var array
 	 */
 	protected $target_functions = array(
-		'wp_enqueue_style' => array(
-			'bootstrapcdn.com' => 'bootstrapcdn.com',
-			'maxcdn.com'       => 'maxcdn.com',
-			'jquery.com'       => 'jquery.com',
-			'cdnjs.com'        => 'cdnjs.com',
-			'googlecode.com'   => 'googlecode.com',
-			),
-		'wp_enqueue_script' => array(
-			'bootstrapcdn.com' => 'bootstrapcdn.com',
-			'maxcdn.com'       => 'maxcdn.com',
-			'jquery.com'       => 'jquery.com',
-			'cdnjs.com'        => 'cdnjs.com',
-			'googlecode.com'   => 'googlecode.com',
-			),
-		);
+		'wp_enqueue_style'  => 2,
+		'wp_enqueue_script' => 2,
+	);
+
+	/**
+	 * Array of CDN URLs.
+	 *
+	 * @since 0.xx.0
+	 *
+	 * @var array
+	 */
+	protected $cdn_urls = array(
+		'bootstrapcdn.com' => 'bootstrapcdn.com',
+		'maxcdn.com'       => 'maxcdn.com',
+		'jquery.com'       => 'jquery.com',
+		'cdnjs.com'        => 'cdnjs.com',
+		'googlecode.com'   => 'googlecode.com',
+	);
 
 	/**
 	 * Process the parameters of a matched function.
@@ -65,16 +71,19 @@ class WordPress_Sniffs_Theme_NoCDNSniff extends WordPress_AbstractFunctionParame
 	 */
 	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
 
-		if ( ! isset( $parameters[2] ) ) {
+		$position = $this->target_functions[ $matched_content ];
+
+		if ( ! isset( $parameters[ $position ] ) ) {
 			return;
 		}
 
-		$matched_parameter = $this->strip_quotes( $parameters[2]['raw'] );
+		$matched_parameter = $this->strip_quotes( $parameters[ $position ]['raw'] );
 
-		foreach ( $this->target_functions[ $matched_content ] as $key => $value ) {
-			if ( false !== strpos( $matched_parameter, $value ) ) {
+		foreach ( $this->cdn_urls as $cdn ) {
+			if ( false !== strpos( $matched_parameter, $cdn ) ) {
 				$this->phpcsFile->addError( 'Loading resources from %s is prohibited.', $stackPtr, $matched_parameter . ' Found', array( $matched_parameter ) );
 			}
 		}
+
 	}
 }

--- a/WordPress/Sniffs/Theme/NoCDNSniff.php
+++ b/WordPress/Sniffs/Theme/NoCDNSniff.php
@@ -78,7 +78,7 @@ class WordPress_Sniffs_Theme_NoCDNSniff implements PHP_CodeSniffer_Sniff {
 					}
 				}
 
-				if ( false !== strpos( $match[0], 'cdn' ) && $found === false ) {
+				if ( false !== strpos( $match[0], 'cdn' ) && false === $found ) {
 					$phpcsFile->addWarning( 'Possible URL of a CDN has been found. The CSS or JavaScript resources cannot be loaded from a CDN but must be bundled.', $stackPtr, 'CDNFound' );
 				}
 			}

--- a/WordPress/Sniffs/Theme/NoCDNSniff.php
+++ b/WordPress/Sniffs/Theme/NoCDNSniff.php
@@ -84,6 +84,10 @@ class WordPress_Sniffs_Theme_NoCDNSniff extends WordPress_AbstractFunctionParame
 
 		$matched_parameter = $this->strip_quotes( $parameters[ $position ]['raw'] );
 
+		if ( false === strpos( $matched_parameter, '.com' ) && false === strpos( $matched_parameter, '.net' ) ) {
+			return;
+		}
+
 		foreach ( $this->cdn_urls as $cdn ) {
 			if ( false !== strpos( $matched_parameter, $cdn ) ) {
 				$this->phpcsFile->addError( 'Loading resources from %s is prohibited.', $stackPtr, $matched_parameter . ' Found', array( $matched_parameter ) );

--- a/WordPress/Sniffs/Theme/NoCDNSniff.php
+++ b/WordPress/Sniffs/Theme/NoCDNSniff.php
@@ -50,11 +50,16 @@ class WordPress_Sniffs_Theme_NoCDNSniff extends WordPress_AbstractFunctionParame
 	 * @var array
 	 */
 	protected $cdn_urls = array(
-		'bootstrapcdn.com' => 'bootstrapcdn.com',
-		'maxcdn.com'       => 'maxcdn.com',
-		'jquery.com'       => 'jquery.com',
-		'cdnjs.com'        => 'cdnjs.com',
-		'googlecode.com'   => 'googlecode.com',
+		'bootstrapcdn.com'      => 'bootstrapcdn.com',
+		'maxcdn.com'            => 'maxcdn.com',
+		'jquery.com'            => 'jquery.com',
+		'cdnjs.com'             => 'cdnjs.com',
+		'googlecode.com'        => 'googlecode.com',
+		'cdnjs.cloudflare.com'  => 'cdnjs.cloudflare.com',
+		'ajax.googleapis.com'   => 'ajax.googleapis.com',
+		'cdn.jsdelivr.net'      => 'cdn.jsdelivr.net',
+		'use.fontawesome.com'   => 'use.fontawesome.com',
+		'opensource.keycdn.com' => 'opensource.keycdn.com',
 	);
 
 	/**
@@ -82,6 +87,7 @@ class WordPress_Sniffs_Theme_NoCDNSniff extends WordPress_AbstractFunctionParame
 		foreach ( $this->cdn_urls as $cdn ) {
 			if ( false !== strpos( $matched_parameter, $cdn ) ) {
 				$this->phpcsFile->addError( 'Loading resources from %s is prohibited.', $stackPtr, $matched_parameter . ' Found', array( $matched_parameter ) );
+				break;
 			}
 		}
 

--- a/WordPress/Sniffs/Theme/NoCDNSniff.php
+++ b/WordPress/Sniffs/Theme/NoCDNSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Restricts the use of the CDN URLs.
+ *
+ * @link https://make.wordpress.org/themes/handbook/review/required/
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.xx.0
+ */
+class WordPress_Sniffs_Theme_NoCDNSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+		'CSS',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+			T_CONSTANT_ENCAPSED_STRING,
+			T_INLINE_HTML,
+			T_URL,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		// List of CDN's not allowed.
+		$cdn_list = array(
+			'maxcdn.bootstrapcdn.com',
+			'netdna.bootstrapcdn.com',
+			'html5shiv.googlecode.com/svn/trunk/html5.js',
+			'oss.maxcdn.com',
+			'code.jquery.com',
+			'cdnjs.com',
+		);
+
+		if ( preg_match_all( '#(?:(?:http|https|ftp):)?//([[:alnum:]\-\.])+(\\.)([[:alnum:]]){2,4}([[:blank:][:alnum:]\/\+\=\%\&\_\\\.\~\?\-]*)#' , $token['content'], $matches, PREG_SET_ORDER ) ) {
+
+			foreach ( $matches as $match ) {
+				$found = false;
+
+				foreach ( $cdn_list as $cdn_url ) {
+					if ( false !== strpos( $match[0], $cdn_url ) ) {
+						$phpcsFile->addError( 'Found the URL to a CDN: (' . $cdn_url . ') The CSS or JavaScript resources cannot be loaded from a CDN but must be bundled.', $stackPtr, 'CDNFound' );
+						$found = true;
+					}
+				}
+
+				if ( false !== strpos( $match[0], 'cdn' ) && $found === false ) {
+					$phpcsFile->addWarning( 'Possible URL of a CDN has been found. The CSS or JavaScript resources cannot be loaded from a CDN but must be bundled.', $stackPtr, 'CDNFound' );
+				}
+			}
+		}
+	}
+}

--- a/WordPress/Tests/Theme/NoCDNUnitTest.inc
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.inc
@@ -1,29 +1,5 @@
-/* ----- Bad ------- ERROR ---- */
-<link href='http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' />
-<link href='http://netdna.bootstrapcdn.com/bootstrap/file.ext' />
-<link href='http://maxcdn.bootstrapcdn.com/bootswatch/file.ext' />
-<link href='http://netdna.bootstrapcdn.com/bootswatch/file.ext' />
-<link href='http://maxcdn.bootstrapcdn.com/font-awesome/file.ext' />
-<link href='http://netdna.bootstrapcdn.com/font-awesome/file.ext' />
-<script src="https://oss.maxcdn.com/libs/html5shiv/file.js"></script>
-<script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<script src="https://oss.maxcdn.com/libs/html5shiv/html5.js"></script>
-<script src="https://code.jquery.com/jquery-whatever/file.js"></script>
-<script src="https://oss.maxcdn.com/libs/respond.js"></script>
-
-/* ----- Bad ------- WARNING ---- */
-<script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
-<link href='http://www.mycdnsite.com/file.css' />
-
-/* ----- Good ------ */
-<link rel="profile" href="http://gmpg.org/xfn/11">  <!-- OK -->
-<link href='http://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css' />  <!-- OK - Whitelisted URL -->
-/* ----- links in html comments will also be picked up ----- */
-<!-- <a ref="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" >Bootstrap</a> --> <!-- Bad -->
-<!-- Here comes a link! --><a href="http://cdn.mysite.org">some string</a>  <!-- Bad -->
-
 <?php
-// Now lets check inside php
+// Now lets check inside php.
 wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' );  // Bad
 wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootstrap/file.ext' );  // Bad
 wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootswatch/file.ext' );  // Bad

--- a/WordPress/Tests/Theme/NoCDNUnitTest.inc
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.inc
@@ -1,0 +1,41 @@
+/* ----- Bad ------- ERROR ---- */
+<link href='http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' />
+<link href='http://netdna.bootstrapcdn.com/bootstrap/file.ext' />
+<link href='http://maxcdn.bootstrapcdn.com/bootswatch/file.ext' />
+<link href='http://netdna.bootstrapcdn.com/bootswatch/file.ext' />
+<link href='http://maxcdn.bootstrapcdn.com/font-awesome/file.ext' />
+<link href='http://netdna.bootstrapcdn.com/font-awesome/file.ext' />
+<script src="https://oss.maxcdn.com/libs/html5shiv/file.js"></script>
+<script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+<script src="https://oss.maxcdn.com/libs/html5shiv/html5.js"></script>
+<script src="https://code.jquery.com/jquery-whatever/file.js"></script>
+<script src="https://oss.maxcdn.com/libs/respond.js"></script>
+
+/* ----- Bad ------- WARNING ---- */
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
+<link href='http://www.mycdnsite.com/file.css' />
+
+/* ----- Good ------ */
+<link rel="profile" href="http://gmpg.org/xfn/11">  <!-- OK -->
+<link href='http://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css' />  <!-- OK - Whitelisted URL -->
+/* ----- links in html comments will also be picked up ----- */
+<!-- <a ref="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" >Bootstrap</a> --> <!-- Bad -->
+<!-- Here comes a link! --><a href="http://cdn.mysite.org">some string</a>  <!-- Bad -->
+
+<?php
+// Now lets check inside php
+wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootstrap/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootswatch/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootswatch/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/font-awesome/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootswatch/file.ext' );  // Bad
+wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/html5shiv/file.js' );  // Bad
+wp_enqueue_script( 'bootstrap', 'https://html5shiv.googlecode.com/svn/trunk/html5.js' );  // Bad
+wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/html5shiv/html5.js' );  // Bad
+wp_enqueue_script( 'bootstrap', 'https://code.jquery.com/jquery-whatever/file.js' );  // Bad
+wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/respond.js' );  // Bad
+
+/* ----- links in php comments will not be picked up ----- */
+//wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/respond.js' );
+//wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' );

--- a/WordPress/Tests/Theme/NoCDNUnitTest.inc
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.inc
@@ -6,11 +6,21 @@ wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootswatch/file.e
 wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootswatch/file.ext' );  // Bad
 wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/font-awesome/file.ext' );  // Bad
 wp_enqueue_style( 'bootstrap', 'http://netdna.bootstrapcdn.com/bootswatch/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://cdnjs.cloudflare.com/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://ajax.googleapis.com/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://cdn.jsdelivr.net/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://use.fontawesome.com/file.ext' );  // Bad
+wp_enqueue_style( 'bootstrap', 'http://opensource.keycdn.com/file.ext' );  // Bad
 wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/html5shiv/file.js' );  // Bad
 wp_enqueue_script( 'bootstrap', 'https://html5shiv.googlecode.com/svn/trunk/html5.js' );  // Bad
 wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/html5shiv/html5.js' );  // Bad
 wp_enqueue_script( 'bootstrap', 'https://code.jquery.com/jquery-whatever/file.js' );  // Bad
 wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/respond.js' );  // Bad
+wp_enqueue_script( 'bootstrap', 'http://cdnjs.cloudflare.com/file.ext' );  // Bad
+wp_enqueue_script( 'bootstrap', 'http://ajax.googleapis.com/file.ext' );  // Bad
+wp_enqueue_script( 'bootstrap', 'http://cdn.jsdelivr.net/file.ext' );  // Bad
+wp_enqueue_script( 'bootstrap', 'http://use.fontawesome.com/file.ext' );  // Bad
+wp_enqueue_script( 'bootstrap', 'http://opensource.keycdn.com/file.ext' );  // Bad
 
 /* ----- links in php comments will not be picked up ----- */
 //wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/respond.js' );

--- a/WordPress/Tests/Theme/NoCDNUnitTest.inc
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.inc
@@ -25,3 +25,6 @@ wp_enqueue_script( 'bootstrap', 'http://opensource.keycdn.com/file.ext' );  // B
 /* ----- links in php comments will not be picked up ----- */
 //wp_enqueue_script( 'bootstrap', 'https://oss.maxcdn.com/libs/respond.js' );
 //wp_enqueue_style( 'bootstrap', 'http://maxcdn.bootstrapcdn.com/bootstrap/file.ext' );
+
+// Google fonts are allowed.
+wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css?family=Open+Sans' );  // OK

--- a/WordPress/Tests/Theme/NoCDNUnitTest.php
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.php
@@ -33,6 +33,16 @@ class WordPress_Tests_Theme_NoCDNUnitTest extends AbstractSniffUnitTest {
 			11 => 1,
 			12 => 1,
 			13 => 1,
+			14 => 1,
+			15 => 1,
+			16 => 1,
+			17 => 1,
+			18 => 1,
+			19 => 1,
+			20 => 1,
+			21 => 1,
+			22 => 1,
+			23 => 1,
 		);
 	}
 

--- a/WordPress/Tests/Theme/NoCDNUnitTest.php
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.php
@@ -22,7 +22,6 @@ class WordPress_Tests_Theme_NoCDNUnitTest extends AbstractSniffUnitTest {
 	 */
 	public function getErrorList() {
 		return array(
-			2  => 1,
 			3  => 1,
 			4  => 1,
 			5  => 1,
@@ -33,18 +32,7 @@ class WordPress_Tests_Theme_NoCDNUnitTest extends AbstractSniffUnitTest {
 			10 => 1,
 			11 => 1,
 			12 => 1,
-			22 => 1,
-			27 => 1,
-			28 => 1,
-			29 => 1,
-			30 => 1,
-			31 => 1,
-			32 => 1,
-			33 => 1,
-			34 => 1,
-			35 => 1,
-			36 => 1,
-			37 => 1,
+			13 => 1,
 		);
 	}
 
@@ -54,11 +42,7 @@ class WordPress_Tests_Theme_NoCDNUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			15 => 1,
-			16 => 1,
-			23 => 1,
-		);
+		return array();
 	}
 
 }

--- a/WordPress/Tests/Theme/NoCDNUnitTest.php
+++ b/WordPress/Tests/Theme/NoCDNUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Unit test class for the NoCDN sniff.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.xx.0
+ */
+class WordPress_Tests_Theme_NoCDNUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			2  => 1,
+			3  => 1,
+			4  => 1,
+			5  => 1,
+			6  => 1,
+			7  => 1,
+			8  => 1,
+			9  => 1,
+			10 => 1,
+			11 => 1,
+			12 => 1,
+			22 => 1,
+			27 => 1,
+			28 => 1,
+			29 => 1,
+			30 => 1,
+			31 => 1,
+			32 => 1,
+			33 => 1,
+			34 => 1,
+			35 => 1,
+			36 => 1,
+			37 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			15 => 1,
+			16 => 1,
+			23 => 1,
+		);
+	}
+
+}


### PR DESCRIPTION
Based on https://github.com/WPTRT/WordPress-Coding-Standards/pull/64 PR.

* Warning message updated.
* Maintain coding standard for the files

Fixes #20