### PR TITLE
Ruleset: add the PHPCompatibilityWP standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The WPThemeReview Standard requires:
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.0** or higher.
 * [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) version **1.0.0** or higher.
+* [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) version **1.0.0** or higher.
 
 
 ## Installation
@@ -86,7 +87,7 @@ $ vendor/bin/phpcs -i
 
 If everything went well, the output should look something like this:
 ```
-The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP and WPThemeReview
+The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, PHPCompatibility, PHPCompatibilityWP, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP and WPThemeReview
 ```
 
 

--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -8,6 +8,10 @@
 	<!-- Treat all files as UTF-8. -->
 	<config name="encoding" value="utf-8"/>
 
+	<!-- Themes should be compatible with PHP 5.2 and higher. -->
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibilityWP"/>
+
 	<!-- No PHP short open tags allowed. -->
 	<!-- Covers: https://github.com/Otto42/theme-check/blob/master/checks/phpshort.php -->
 	<rule ref="Generic.PHP.DisallowShortOpenTag"/>

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
 	"require"    : {
 		"php"                      : ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.0",
-		"wp-coding-standards/wpcs" : "^1.0.0"
+		"wp-coding-standards/wpcs" : "^1.0.0",
+		"phpcompatibility/phpcompatibility-wp": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -50,8 +51,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts"    : {
-		"install-standards"    : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs",
-		"install-standards-dev": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/php-compatibility",
+		"install-standards"    : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/phpcompatibility-wp",
+		"install-standards-dev": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/phpcompatibility-wp,../../phpcompatibility/php-compatibility",
 		"run-tests"            : "@php ./vendor/phpunit/phpunit/phpunit --filter WPThemeReview ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
 		"phpcs-i"              : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -i",
 		"check-cs"             : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",


### PR DESCRIPTION
This currently presumes that all themes should be compatible with PHP 5.2-nightly.

At a later point in time, we may be able to make this more configurable by reading out the `Requires PHP:` header in the `style.css` file and, if found, using the minimum PHP version set there for the bottom limit in `testVersion`.

For now, the `testVersion` as set in the ruleset can be overruled from the command-line by passing a `testVersion` as a command-line parameter, like so: `phpcs ... --runtime-set testVersion 5.4-`.

Fixes #173