### PR TITLE
Update for PHPCompatibility 9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The WPThemeReview Standard requires:
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.0** or higher.
 * [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) version **1.0.0** or higher.
-* [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) version **1.0.0** or higher.
+* [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) version **2.0.0** or higher.
 
 
 ## Installation
@@ -87,7 +87,7 @@ $ vendor/bin/phpcs -i
 
 If everything went well, the output should look something like this:
 ```
-The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, PHPCompatibility, PHPCompatibilityWP, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP and WPThemeReview
+The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, PHPCompatibility, PHPCompatibilityParagonieRandomCompat, PHPCompatibilityParagonieSodiumCompat, PHPCompatibilityWP, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP and WPThemeReview
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -40,25 +40,23 @@
 		"php"                      : ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.0",
 		"wp-coding-standards/wpcs" : "^1.0.0",
-		"phpcompatibility/phpcompatibility-wp": "^1.0"
+		"phpcompatibility/phpcompatibility-wp": "^2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
-		"phpcompatibility/php-compatibility": "^8.0",
-		"roave/security-advisories"         : "dev-master"
+		"phpcompatibility/php-compatibility": "^9.0",
+		"roave/security-advisories"         : "dev-master",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
 	},
 	"suggest"    : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts"    : {
-		"install-standards"    : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/phpcompatibility-wp",
-		"install-standards-dev": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/phpcompatibility-wp,../../phpcompatibility/php-compatibility",
+		"install-standards"    : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set installed_paths ../../..,../../wp-coding-standards/wpcs,../../phpcompatibility/phpcompatibility-wp,../../phpcompatibility/phpcompatibility-paragonie",
 		"run-tests"            : "@php ./vendor/phpunit/phpunit/phpunit --filter WPThemeReview ./vendor/squizlabs/php_codesniffer/tests/AllTests.php",
 		"phpcs-i"              : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -i",
 		"check-cs"             : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-		"fix-cs"               : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-		"post-install-cmd"     : "@install-standards-dev",
-		"post-update-cmd"      : "@install-standards-dev"
+		"fix-cs"               : "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
 	},
 	"support"    : {
 		"issues": "https://github.com/WPTRT/WPThemeReview/issues",


### PR DESCRIPTION
[PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) has just been released and renames all sniffs.
[PHPCompatibilityWP 2.0.0](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.0.0) has been released alongside it.

The upgrade for this repo is simple as TRTCS currently doesn't use PHPCS inline annotations which reference PHPCompatibility sniffs, nor uses custom excludes.

As the PHPCompatibilityWP ruleset as of version 2.0 has an additional dependency, it is however opportune to let the DealerDirect plugin sort out the installed paths, at least for devs.

For end-users, the DealerDirect plugin is advised anyway, so hopefully people will listen to that advice ;-)

* Updated the version restrictions in `composer.json`.
* Removed the `install-standards-dev`, `post-install-cmd` and `post-update-cmd` scripts as that will now be sorted out by the DealerDirect plugin.
* Updated the Readme references.