### PR TITLE
Warn on empty statements

### DIFF
--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -45,8 +45,11 @@
 	<!-- No ByteOrderMark allowed - important to prevent issues with content being sent before headers. -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
 
-	<!-- PHP tags without anything between them is just sloppy. -->
+	<!-- Control structures which don't do anything are not very useful. -->
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+
+	<!-- PHP tags without anything between them is just sloppy. -->
+	<rule ref="WordPress.CodeAnalysis.EmptyPHPStatement"/>
 
 	<!-- No removal of the admin bar allowed -->
 	<!-- Covers: https://github.com/wordpress/theme-check/blob/master/checks/adminbar.php -->


### PR DESCRIPTION
Related to PR #152 which added the wrong sniff ... oops.

* The `Generic.CodeAnalsysis.EmptyStatement` (added in #152) checks for empty control structure leafs, i.e.
    ```php
    if ($a = $b) {
        // This would be reported.
    } else {
        $b = $a;
    }
    ```
* `Generic.CodeAnalysis.EmptyPHPStatement` (open PR upstream squizlabs/PHP_CodeSniffer#1814) /`WordPress.CodeAnalysis.EmptyStatement` checks for empty PHP tags `<?php ?>` and double semi-colons, like `statement; ;`.

With this PR, the missing check is added.