### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
     # Allow failures for unstable builds.
     - php: nightly
     - php: 7.3
+      env: PHPCS_BRANCH="3.3.0"
 
 before_install:
   # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and build haven't been tested against PHP 7.3 for months now.

Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've now removed it from the "allowed to fail" list, at least for the higher PHPCS version.

PHP 7.3 in combination with PHPCS 3.x, but lower than 3.3.1 should be allowed to fail as PHPCS wasn't fully compatible with PHP 7.3 until version 3.3.1.