### PR TITLE
Ruleset: bug fix

### DIFF
--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -49,7 +49,7 @@
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
 	<!-- PHP tags without anything between them is just sloppy. -->
-	<rule ref="WordPress.CodeAnalysis.EmptyPHPStatement"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- No removal of the admin bar allowed -->
 	<!-- Covers: https://github.com/wordpress/theme-check/blob/master/checks/adminbar.php -->


### PR DESCRIPTION
Introduced by #182.

Sometimes things get confusing. This sniff is currently already part of WPCS, but is called `WordPress.CodeAnalysis.EmptyStatement`.
The upstream PHPCS version for which the PR has been open for nine months so far, is called `Generic.CodeAnalysis.EmptyPHPStatement`.

My bad for getting the names mixed up ;-)

Fixes #185