### PR TITLE
Update to use WPCS 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	"require"    : {
 		"php"                      : ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.0",
-		"wp-coding-standards/wpcs" : "^1.0.0",
+		"wp-coding-standards/wpcs" : "^1.2.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
WPCS 1.2.0 has just been released: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.2.0

As it is important that themes which use namespaces prefix those namespaces with a theme specific prefix, I suggest upping the minium WPCS version to 1.2.0, which includes a check for that.