### PR TITLE
Bump suggested installer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you use Composer to manage dependencies from your project anyway or are consi
 From the command-line, run the following command from the root directory of your project:
 
 ```bash
-$ php composer.phar require --dev wptrt/wpthemereview:* dealerdirect/phpcodesniffer-composer-installer:^0.4.4
+$ php composer.phar require --dev wptrt/wpthemereview:* dealerdirect/phpcodesniffer-composer-installer:^0.5.0
 ```
 
 > Note:

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,10 @@
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"roave/security-advisories"         : "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
 	},
 	"suggest"    : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts"    : {
 		"install-standards": [


### PR DESCRIPTION
> Below 1.0 minor releases are treated as major releases so `^` locks to current minor release.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1628

Props @Rarst

Version 0.5.0 was released in October 2018, so should be used by now.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases