### PR TITLE
Travis: test builds against PHP 7.4 & work around for PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ matrix:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - php: 7.3
-      env: PHPCS_BRANCH="3.3.1"
 
 before_install:
   # Speed up build time by disabling Xdebug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
   - 7.0
   - 7.1
   - 7.3
+  - "7.4snapshot"
   - nightly
 
 env:
@@ -43,6 +44,7 @@ matrix:
 
   allow_failures:
     # Allow failures for unstable builds.
+    - php: "7.4snapshot"
     - php: nightly
     - php: 7.3
       env: PHPCS_BRANCH="3.3.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ php:
   - 7.1
   - 7.3
   - "7.4snapshot"
-  - nightly
 
 env:
   # Highest supported PHPCS version.
@@ -45,7 +44,6 @@ matrix:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - php: nightly
     - php: 7.3
       env: PHPCS_BRANCH="3.3.1"
 
@@ -56,11 +54,10 @@ before_install:
   - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} --no-update --no-suggest --no-scripts
   - |
     if [[ "$SNIFF" == "1" ]]; then
-      # Use the Travis image PHPUnit version rather than installing via Composer.
-      composer remove --dev phpunit/phpunit --no-update --no-suggest --no-scripts
       composer install --dev --no-suggest
       # The post-install-cmd script takes care of the installed_paths.
     else
+      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
       composer install --no-dev --no-suggest --no-scripts
       composer install-standards
     fi
@@ -69,7 +66,12 @@ script:
   # Lint the PHP files against parse errors.
   - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
   # Run the unit tests.
-  - phpunit --filter WPThemeReview $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+      vendor/bin/phpunit --filter WPThemeReview $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    else
+      phpunit --filter WPThemeReview $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
+    fi
   # Check the codestyle of the WPThemeReview codebase.
   - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs; fi
   # Validate the xml files.


### PR DESCRIPTION
### Travis: test builds against PHP 7.4

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

### Travis: work around PHPUnit 8.x on PHP >= 7.2 images

As of recently, the Travis images for PHP 7.2+ ship with PHPUnit 8.x.
The PHPCS native test framework is not compatible with PHPUnit 8.x and won't be able to be made compatible with it until the minimum PHP version would be raised to PHP 7.1.

So for the unit tests to be able to run on PHP 7.2+, we need to explicitly require PHPUnit 7.x for those builds.

As for nightly: there is no PHPUnit version which is currently compatible with PHP 8.
As that either means that the builds for `nightly` would always fail or - if the unit tests would be skipped -, the only check executed on `nightly` would be linting the files, I've elected to remove build testing against `nightly` for the time being.

For more details about PHPUnit vs PHPCS vs PHP 8, see squizlabs/PHP_CodeSniffer#2416