### PR TITLE
prevent phpcs PHP internal msg on css/js sniffs

### DIFF
--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -16,6 +16,11 @@
 	<!-- Alternative PHP open tags not allowed. -->
 	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
 
+	<!-- Restrict PHPCS' internal error message for short tag use/no code to PHP files only. -->
+	<rule ref="Internal.NoCodeFound">
+		<include-pattern>*\.(php|inc)$</include-pattern>
+	</rule>
+
 	<!-- Files which start with a PHP open tag should have no whitespace preceding it. -->
 	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
 		<message>To help prevent PHP "headers already sent" errors, whitespace before the PHP open tag should be removed.</message>


### PR DESCRIPTION
Initially reported by @Mocha365 in issue https://github.com/WPTRT/theme-sniffer/issues/140.  It looks like the internal message from phpcs gets thrown on css/js file sniffs.  Initially I thought it might have been because the runner isn't actually setting the extensions, but even after doing that it wasn't suppressed.  This pull will just restrict it to only the php/inc extensions.