### PR TITLE
Composer: use WPCS ^2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ env:
   # Highest supported PHPCS + WPCS versions.
   - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" LINT=1
   # Lowest supported PHPCS + WPCS versions.
-  - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.0.0"
+  - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.1.0"
 
 matrix:
   fast_finish: true
   include:
     # Seperate builds for PHP 7.2 with additional checks.
     - php: 7.2
-      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.0.0" LINT=1 SNIFF=1
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.1.0" LINT=1 SNIFF=1
       addons:
         apt:
           packages:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This project attempts to automate the code analysis part of the [Theme Review Pr
 The WPThemeReview Standard requires:
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.1** or higher.
-* [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) version **2.0.0** or higher.
+* [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) version **2.1.0** or higher.
 * [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) version **2.0.0** or higher.
 
 
@@ -87,7 +87,9 @@ $ vendor/bin/phpcs -i
 
 If everything went well, the output should look something like this:
 ```
-The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, PHPCompatibility, PHPCompatibilityParagonieRandomCompat, PHPCompatibilityParagonieSodiumCompat, PHPCompatibilityWP, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra, WordPress-VIP and WPThemeReview
+The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, PHPCompatibility,
+PHPCompatibilityParagonieRandomCompat, PHPCompatibilityParagonieSodiumCompat, PHPCompatibilityWP,
+WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra and WPThemeReview
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	"require"    : {
 		"php"                      : ">=5.4",
 		"squizlabs/php_codesniffer": "^3.3.1",
-		"wp-coding-standards/wpcs" : "^2.0.0",
+		"wp-coding-standards/wpcs" : "^2.1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
WPCS 2.1.0 has been released and contains quite some bug fixes, most notably in the security related sniffs.

Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.1.0

Includes removing a reference to `WordPress-VIP` from the readme. `WordPress-VIP` was removed in WPCS 2.0.0.