### PR TITLE
Add Reserved Template Name Sniff

### DIFF
--- a/WPThemeReview/Sniffs/Templates/ReservedFileNamePrefixSniff.php
+++ b/WPThemeReview/Sniffs/Templates/ReservedFileNamePrefixSniff.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * WPThemeReview Coding Standard.
+ *
+ * @package WPTRT\WPThemeReview
+ * @link    https://github.com/WPTRT/WPThemeReview
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WPThemeReview\Sniffs\Templates;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Check if the template file is using a prefix which would cause WP to interpret it as a specialised template
+ * meant to apply to only one page on the site.
+ *
+ * You can check the documentation of each of the functions used in determining the template hierarchy.
+ *
+ * @link https://developer.wordpress.org/reference/functions/get_category_template
+ * @link https://developer.wordpress.org/reference/functions/get_author_template
+ * @link https://developer.wordpress.org/reference/functions/get_page_template
+ * @link https://developer.wordpress.org/reference/functions/get_tag_template
+ *
+ * Or you can check the in depth documentation about the template hierarchy.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy
+ *
+ * @since 0.2.0
+ */
+class ReservedFileNamePrefixSniff implements Sniff {
+
+	/**
+	 * Error message template.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var string
+	 */
+	const ERROR_MSG = 'Template files should not be slug specific. The file name used for this template will be interpreted by WP as %1$s-%2$s and only applied when a %1$s with the slug "%2$s" is loaded.';
+
+	/**
+	 * Found prefix in a file.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var string
+	 */
+	protected $prefix;
+
+	/**
+	 * File slug.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var string
+	 */
+	protected $slug;
+
+	/**
+	 * List of reserved template file names.
+	 *
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+	 * @link https://developer.wordpress.org/themes/template-files-section/partial-and-miscellaneous-template-files/#content-slug-php
+	 * @link https://wphierarchy.com/
+	 * @link https://en.wikipedia.org/wiki/Media_type#Naming
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var array
+	 */
+	protected $reserved_file_name_prefixes = [
+		'author'   => true,
+		'category' => true,
+		'page'     => true,
+		'tag'      => true,
+	];
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			\T_OPEN_TAG,
+			\T_OPEN_TAG_WITH_ECHO,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+	 *                                               token was found.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack.
+	 *
+	 * @return int StackPtr to the end of the file, this sniff needs to only
+	 *             check each file once.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+
+		// Usage of `strip_quotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
+		$file = $this->strip_quotes( $phpcsFile->getFileName() );
+
+		$fileName = basename( $file );
+		$fileName = str_replace( [ '.inc', '.php' ], '', $fileName );
+
+		// Check if the current file has a prefix in the reserved list.
+		if ( ! $this->is_reserved_template_name_used( $fileName ) ) {
+			return ( $phpcsFile->numTokens + 1 );
+		}
+
+		$phpcsFile->addError(
+			self::ERROR_MSG,
+			0,
+			'ReservedTemplatePrefixFound',
+			array( $this->prefix, $this->slug )
+		);
+
+		return ( $phpcsFile->numTokens + 1 );
+	}
+
+	/**
+	 * Checks if the given file name starts with one of the reserved prefixes.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param  string $file File name to check.
+	 * @return boolean
+	 */
+	private function is_reserved_template_name_used( $file ) {
+		$file_parts = explode( '-', $file, 2 );
+
+		if ( empty( $file_parts[0] ) || empty( $file_parts[1] ) ) {
+			// No dash or dash at start or end of filename, i.e. `-something.php`.
+			return false;
+		}
+
+		if ( isset( $this->reserved_file_name_prefixes[ strtolower( $file_parts[0] ) ] ) ) {
+			$this->prefix = $file_parts[0];
+			$this->slug   = $file_parts[1];
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Strip quotes surrounding an arbitrary string.
+	 *
+	 * Intended for use with the contents of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
+	 *
+	 * Copied from the WordPressCS\WordPress\Sniff abstract class.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param string $string The raw string.
+	 * @return string String without quotes around it.
+	 */
+	private function strip_quotes( $string ) {
+		return preg_replace( '`^([\'"])(.*)\1$`Ds', '$2', $string );
+	}
+}

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/-tag.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/-tag.inc
@@ -1,0 +1,18 @@
+<?php
+get_header();
+?>
+  <section id="primary" class="content-area tag">
+    <main id="main" class="site-main">
+      <?php
+      while ( have_posts() ) :
+        the_post();
+        get_template_part( 'template-parts/content', 'tag' );
+        if ( comments_open() || get_comments_number() ) {
+          comments_template();
+        }
+      endwhile;
+      ?>
+    </main>
+  </section>
+<?php
+get_footer();

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/Page-info.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/Page-info.inc
@@ -1,0 +1,19 @@
+<?php
+/* Template Name: Info page template */
+
+// code goes here
+
+?>
+  <div id="pageheader" class="titleclass">
+    <div class="container">
+      <?php get_template_part('templates/page', 'header'); ?>
+    </div><!--container-->
+  </div><!--titleclass-->
+<?php if ($map == 'yes') { ?>
+  <div id="pageheader" class="titleclass">
+    <div class="container">
+      <div id="map_address">
+      </div>
+    </div><!--container-->
+  </div><!--titleclass-->
+<?php } ?>

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/category-.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/category-.inc
@@ -1,0 +1,18 @@
+<?php
+get_header();
+?>
+  <section id="primary" class="content-area category">
+    <main id="main" class="site-main">
+      <?php
+      while ( have_posts() ) :
+        the_post();
+        get_template_part( 'template-parts/content', 'category' );
+        if ( comments_open() || get_comments_number() ) {
+          comments_template();
+        }
+      endwhile;
+      ?>
+    </main>
+  </section>
+<?php
+get_footer();

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/category-books.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/category-books.inc
@@ -1,0 +1,4 @@
+<!-- Template Name: Books category template -->
+<div class="some-class-name">
+  <?= 'This is an echo'; ?>
+</div>

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/front-contact.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/front-contact.inc
@@ -1,0 +1,4 @@
+<?php
+/* Template Name: Contact front page template */
+
+// code goes here

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/index-secondary.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/index-secondary.inc
@@ -1,0 +1,4 @@
+<?php
+/* Template Name: secondary home page template */
+
+// code goes here

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/page-contact-form.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/page-contact-form.inc
@@ -1,0 +1,19 @@
+<?php
+/* Template Name: Contact page template */
+
+// code goes here
+
+?>
+  <div id="pageheader" class="titleclass">
+    <div class="container">
+      <?php get_template_part('templates/page', 'header'); ?>
+    </div><!--container-->
+  </div><!--titleclass-->
+<?php if ($map == 'yes') { ?>
+  <div id="pageheader" class="titleclass">
+    <div class="container">
+      <div id="map_address">
+      </div>
+    </div><!--container-->
+  </div><!--titleclass-->
+<?php } ?>

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/page.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/page.inc
@@ -1,0 +1,18 @@
+<?php
+get_header();
+?>
+  <section id="primary" class="content-area">
+    <main id="main" class="site-main">
+      <?php
+      while ( have_posts() ) :
+        the_post();
+        get_template_part( 'template-parts/content/content', 'page' );
+        if ( comments_open() || get_comments_number() ) {
+          comments_template();
+        }
+      endwhile;
+      ?>
+    </main>
+  </section>
+<?php
+get_footer();

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/tmplt-contact.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixTests/tmplt-contact.inc
@@ -1,0 +1,4 @@
+<?php
+/* Template Name: Contact page template */
+
+// code goes here

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixUnitTest.inc
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixUnitTest.inc
@@ -1,0 +1,2 @@
+<?php
+// Dummy file. The real test files are in the ReservedFileNamePrefixTests subfolder.

--- a/WPThemeReview/Tests/Templates/ReservedFileNamePrefixUnitTest.php
+++ b/WPThemeReview/Tests/Templates/ReservedFileNamePrefixUnitTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Unit test class for WPThemeReview Coding Standard.
+ *
+ * @package WPTRT\WPThemeReview
+ * @link    https://github.com/WPTRT/WPThemeReview
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WPThemeReview\Tests\Templates;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the ReservedFileNamePrefix sniff.
+ *
+ * @package WPTRT\WPThemeReview
+ *
+ * @since 0.2.0
+ */
+class ReservedFileNamePrefixUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Get a list of all test files to check.
+	 *
+	 * @param string $testFileBase The base path that the unit tests files will have.
+	 *
+	 * @return string[]
+	 */
+	protected function getTestFiles( $testFileBase ) {
+		$sep        = \DIRECTORY_SEPARATOR;
+		$test_files = glob( dirname( $testFileBase ) . $sep . 'ReservedFileNamePrefixTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
+
+		if ( ! empty( $test_files ) ) {
+			return $test_files;
+		}
+		return array( $testFileBase . '.inc' );
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'category-books.inc':
+			case 'page-contact-form.inc':
+			case 'Page-info.inc':
+				return array(
+					1 => 1,
+				);
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
This is a PR for #212 issue.

I'm sure more test cases would be a good idea, and I'm not 100% sure if I should check for the comment at all, or just check for prefixed file names.

One thing that I had to add was `strip_quotes` method from the WPCS `Sniff` abstract class.

Should I have just extended that sniff instead of implementing the `Sniff` interface from PHPCS (seeing how WPCS's abstract `Sniff` class already implements it).