### PR TITLE
Include post per page rule and make it into a warning

### DIFF
--- a/WPThemeReview/Sniffs/CoreFunctionality/PostsPerPageSniff.php
+++ b/WPThemeReview/Sniffs/CoreFunctionality/PostsPerPageSniff.php
@@ -15,8 +15,9 @@ use WordPressCS\WordPress\Sniffs\WP\PostsPerPageSniff as WPCSPostsPerPageSniff;
  * Flag returning high or infinite posts_per_page.
  *
  * This sniff extends the upstream WPCS PostsPerPageSniff. The difference is that this
- * sniff will warn against using -1 as posts_per_page setting while querying posts,
- * due to detrimental effects it has on query speed.
+ * sniff will not only warn against a high pagination limit, but will also warn against
+ * using -1 as posts_per_page setting while querying posts, due to detrimental effects
+ * it has on query speed.
  *
  * @link https://github.com/WPTRT/WPThemeReview/issues/147
  *

--- a/WPThemeReview/Sniffs/CoreFunctionality/PostsPerPageSniff.php
+++ b/WPThemeReview/Sniffs/CoreFunctionality/PostsPerPageSniff.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WPThemeReview Coding Standard.
+ *
+ * @package WPTRT\WPThemeReview
+ * @link    https://github.com/WPTRT/WPThemeReview
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WPThemeReview\Sniffs\CoreFunctionality;
+
+use WordPressCS\WordPress\Sniffs\WP\PostsPerPageSniff as WPCSPostsPerPageSniff;
+
+/**
+ * Flag returning high or infinite posts_per_page.
+ *
+ * This sniff extends the upstream WPCS PostsPerPageSniff. The difference is that this
+ * sniff will warn against using -1 as posts_per_page setting while querying posts,
+ * due to detrimental effects it has on query speed.
+ *
+ * @link https://github.com/WPTRT/WPThemeReview/issues/147
+ *
+ * @since 0.2.0
+ */
+class PostsPerPageSniff extends WPCSPostsPerPageSniff {
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		$this->posts_per_page = (int) $this->posts_per_page;
+
+		if ( '-1' === $val ) {
+			return 'Disabling pagination is not advised, avoid setting `%s` to `%s`';
+		}
+
+		if ( $val > $this->posts_per_page ) {
+			return 'Detected high pagination limit, `%s` is set to `%s`';
+		}
+
+		return false;
+	}
+}

--- a/WPThemeReview/Tests/CoreFunctionality/PostsPerPageUnitTest.inc
+++ b/WPThemeReview/Tests/CoreFunctionality/PostsPerPageUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+$args = array(
+  'posts_per_page' => 999, // Bad.
+  'posts_per_page' => -1, // Bad.
+  'posts_per_page' => 1, // OK.
+  'posts_per_page' => '1', // OK.
+  'posts_per_page' => '-1', // Bad.
+);
+_query_posts( 'nopaging=true&posts_per_page=999' ); // Bad.
+_query_posts( 'nopaging=true&posts_per_page=-1' ); // Bad.
+_query_posts( 'numberposts=999' ); // Bad.
+_query_posts( 'numberposts=-1' ); // Bad.
+$query_args['posts_per_page'] = 999; // Bad.
+$query_args['posts_per_page'] = 1; // OK.
+$query_args['posts_per_page'] = '1'; // OK.
+$query_args['numberposts'] = '-1'; // Bad.
+$query_args['my_posts_per_page'] = -1; // Ok.
+// phpcs:set WPThemeReview.CoreFunctionality.PostsPerPage posts_per_page 50
+ $query_args['posts_per_page'] = -1; // Bad.
+ $query_args['posts_per_page'] = 50; // OK.
+ $query_args['posts_per_page'] = 100; // Bad.
+ $query_args['posts_per_page'] = 200; // Bad.
+ $query_args['posts_per_page'] = 300; // Bad.
+// phpcs:set WPThemeReview.CoreFunctionality.PostsPerPage posts_per_page 200
+ $query_args['posts_per_page'] = -1; // Bad.
+ $query_args['posts_per_page'] = 50; // OK.
+ $query_args['posts_per_page'] = 100; // OK.
+ $query_args['posts_per_page'] = 200; // OK.
+ $query_args['posts_per_page'] = 300; // Bad.
+// phpcs:set WPThemeReview.CoreFunctionality.PostsPerPage posts_per_page 100

--- a/WPThemeReview/Tests/CoreFunctionality/PostsPerPageUnitTest.php
+++ b/WPThemeReview/Tests/CoreFunctionality/PostsPerPageUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Unit test class for WPThemeReview Coding Standard.
+ *
+ * @package WPTRT\WPThemeReview
+ * @link    https://github.com/WPTRT/WPThemeReview
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WPThemeReview\Tests\CoreFunctionality;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the PostsPerPage sniff.
+ *
+ * @package WPTRT\WPThemeReview
+ *
+ * @since 0.2.0
+ */
+class PostsPerPageUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array(
+			3  => 1,
+			4  => 1,
+			7  => 1,
+			9  => 1,
+			10 => 1,
+			11 => 1,
+			12 => 1,
+			13 => 1,
+			16 => 1,
+			19 => 1,
+			21 => 1,
+			22 => 1,
+			23 => 1,
+			25 => 1,
+			29 => 1,
+		);
+	}
+
+}

--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -159,4 +159,8 @@
 	<!-- Themes should never touch the timezone. -->
 	<rule ref="WordPress.WP.TimezoneChange"/>
 
+	<!-- Downgrade posts per page rule into warning instead of error. -->
+	<rule ref="WordPress.WP.PostsPerPage">
+		<type>warning</type>
+	</rule>
 </ruleset>

--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -159,8 +159,4 @@
 	<!-- Themes should never touch the timezone. -->
 	<rule ref="WordPress.WP.TimezoneChange"/>
 
-	<!-- Downgrade posts per page rule into warning instead of error. -->
-	<rule ref="WordPress.WP.PostsPerPage">
-		<type>warning</type>
-	</rule>
 </ruleset>


### PR DESCRIPTION
As noted in the issue #147 there was an agreement in the meeting to use the posts per page sniff, but that the ruleset should throw a warning instead of an error.