### PR TITLE
Add rule about setting INI during runtime in themes

### DIFF
--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -159,4 +159,10 @@
 	<!-- Themes should never touch the timezone. -->
 	<rule ref="WordPress.WP.TimezoneChange"/>
 
+	<!-- Themes shouldn't change ini configuration during runtime. -->
+	<rule ref="WordPress.PHP.IniSet">
+		<type>error</type>
+	</rule>
+
+
 </ruleset>


### PR DESCRIPTION
Add rule that forbids the setting of INI configuration in themes.

Related issue #209 