### PR TITLE
Rulesets: Add XSD schema tags and validate rulesets against schema (PHPCS 3.2+/3.3.2+)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WPThemeReview Coding Standards">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPThemeReview Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<description>The Coding standard for the WPThemeReview Standards itself.</description>
 
 	<file>.</file>

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs; fi
   # Validate the xml files.
   # @link http://xmlsoft.org/xmllint.html
-  - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./*/ruleset.xml; fi
+  - if [[ "$SNIFF" == "1" ]]; then xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./*/ruleset.xml; fi
   # Check the code-style consistency of the xml files.
   - if [[ "$SNIFF" == "1" ]]; then diff -B --tabsize=4 ./WPThemeReview/ruleset.xml <(xmllint --format "./WPThemeReview/ruleset.xml"); fi
   # Validate the composer.json file.

--- a/WPThemeReview/ruleset.xml
+++ b/WPThemeReview/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WPThemeReview">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPThemeReview" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
 	<!-- For more information: https://make.wordpress.org/themes/handbook/review/ -->
 	<description>Standards any Theme to be published on wordpress.org should comply with.</description>
 


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS includes an XSD schema for rulesets which defines what can be used in the XML ruleset file.

In PHPCS 3.3.0 a new array format for properties was introduced and as of PHPCS 3.3.2, the new array format is now also covered by this schema.

This commit:
* Adds the schema tags to the `ruleset.xml` files and the WPTRTCS native `.phpcs.xml.dist` file.
* Adds validation against the schema for the `ruleset.xml` file to the Travis build.

Fixes #175