### PR TITLE
Travis: remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: trusty
 
 cache:


### PR DESCRIPTION
Travis will (soon, if not already) no longer support this directive: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration