### PR TITLE
Travis: ignore PHP deprecation notices for stable PHPCS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ php:
 
 env:
   # Highest supported PHPCS + WPCS versions.
-  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" LINT=1
+  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop" LINT=1
   # Lowest supported PHPCS + WPCS versions.
   - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.1.0"
 
@@ -56,7 +56,7 @@ jobs:
       php: 7.2
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.1.0" LINT=1
     - php: 7.2
-      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-master"
+      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-develop"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -65,6 +65,14 @@ jobs:
 before_install:
   # Speed up build time by disabling Xdebug.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+  # On stable PHPCS versions, allow for PHP deprecation notices.
+  # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS_BRANCH != "dev-develop" ]]; then
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
   - export XMLLINT_INDENT="	"
   - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
   - |


### PR DESCRIPTION
The unit tests will fail when a PHP warning/notice/deprecation notice is encountered.

Deprecation notices thrown by already released PHPCS versions won't get fixed anymore (in that version), so failing the unit tests on those is moot and will skew the reliability of the Travis results.

To see the effect you'd need to check the Travis logs for the PHP 7.4 builds and compare them with a recent build on another branch, like https://travis-ci.org/WPTRT/WPThemeReview/builds/561796063 .