### PR TITLE
PrefixAllGlobals: update method signature for compatibility with WPCS 2.2.0

### DIFF
--- a/WPThemeReview/Sniffs/CoreFunctionality/PrefixAllGlobalsSniff.php
+++ b/WPThemeReview/Sniffs/CoreFunctionality/PrefixAllGlobalsSniff.php
@@ -130,13 +130,16 @@ class PrefixAllGlobalsSniff extends WPCSPrefixAllGlobalsSniff {
 	 * local to that function.
 	 *
 	 * @since 0.2.0
+	 * @since 0.x.x  Added $in_list parameter as introduced in WPCS 2.2.0.
 	 *
-	 * @param int $stackPtr The position of the current token in the stack.
+	 * @param int  $stackPtr The position of the current token in the stack.
+	 * @param bool $in_list  Whether or not this is a variable in a list assignment.
+	 *                       Defaults to false.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	protected function process_variable_assignment( $stackPtr ) {
+	protected function process_variable_assignment( $stackPtr, $in_list = false ) {
 
 		// Usage of `strip_quotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
 		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
@@ -161,7 +164,7 @@ class PrefixAllGlobalsSniff extends WPCSPrefixAllGlobalsSniff {
 		}
 
 		// Not a typical template file name, defer to the prefix checking in the parent sniff.
-		return parent::process_variable_assignment( $stackPtr );
+		return parent::process_variable_assignment( $stackPtr, $in_list );
 	}
 
 	/**


### PR DESCRIPTION
WPCS 2.2.0 changes the method signature of the `PrefixAllGlobalsSniff::process_variable_assignment()` method, adding a new `$in_list` parameter.

This means that the method signature for the method as overloaded in WPTRTCS needs to be updated to prevent the following PHP warning `Declaration of WPThemeReview\Sniffs\CoreFunctionality\PrefixAllGlobalsSniff::process_variable_assignment($stackPtr) should be compatible with WordPressCS\WordPress\Sniffs\NamingConventions\PrefixAllGlobalsSniff::process_variable_assignment($stackPtr, $in_list = false)`.

It it safe to add this new parameter to WPThemeReview already, even though WPCS 2.2.0 hasn't been released yet, as passing _too many_ parameters to a function and/or adding an additional parameter to an overloaded method in a child class does not cause issues in PHP, while having _too few_ parameters will, as the above warning demonstrates.

Refs:
* https://github.com/WordPress/WordPress-Coding-Standards/pull/1783