### PR TITLE
PrefixAllGlobals sniff - add the version number in the docblock

### DIFF
--- a/WPThemeReview/Sniffs/CoreFunctionality/PrefixAllGlobalsSniff.php
+++ b/WPThemeReview/Sniffs/CoreFunctionality/PrefixAllGlobalsSniff.php
@@ -130,7 +130,7 @@ class PrefixAllGlobalsSniff extends WPCSPrefixAllGlobalsSniff {
 	 * local to that function.
 	 *
 	 * @since 0.2.0
-	 * @since 0.x.x  Added $in_list parameter as introduced in WPCS 2.2.0.
+	 * @since 0.2.1  Added $in_list parameter as introduced in WPCS 2.2.0.
 	 *
 	 * @param int  $stackPtr The position of the current token in the stack.
 	 * @param bool $in_list  Whether or not this is a variable in a list assignment.


### PR DESCRIPTION
Since WPCS 2.2.0 was released, I'm getting errors when working with theme sniffer (I updated the packages), so I thought we'd release this as a part of the 0.2.1. hotfix release (I'll try to sort the rest of the issues in some reasonable milestones so that we get this thing going).