### PR TITLE
Travis: don't allow PHP 7.4 build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,6 @@ jobs:
     - php: 7.2
       env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-develop"
 
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "7.4snapshot"
-
 before_install:
   # Speed up build time by disabling Xdebug.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'


### PR DESCRIPTION
As [PHP 7.4 has been released](https://www.php.net/archive/2019.php#2019-11-28-1), the build against PHP 7.4 should no longer be allowed to fail.