### PR TITLE
Travis/Readme: adjust for minimum requirement of WPCS 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   # Highest supported PHPCS + WPCS versions.
   - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop" LINT=1
   # Lowest supported PHPCS + WPCS versions.
-  - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.1.0"
+  - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.2.0"
 
 stages:
   - sniff
@@ -54,7 +54,7 @@ jobs:
     # Seperate test builds for PHP 7.2 with reversed PHPCS vs WPCS branches.
     - stage: test
       php: 7.2
-      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.1.0" LINT=1
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 7.2
       env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-develop"
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This project attempts to automate the code analysis part of the [Theme Review Pr
 The WPThemeReview Standard requires:
 * PHP 5.4 or higher.
 * [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **3.3.1** or higher.
-* [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) version **2.1.0** or higher.
+* [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) version **2.2.0** or higher.
 * [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) version **2.0.0** or higher.
 
 


### PR DESCRIPTION
PR #239 bumped the minimum required WPCS version to `2.2.0`, but the Travis script, nor the Readme had been adjusted to match.