### PR TITLE
Travis: fix language setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ cache:
     # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer/files
 
-language:
-  - php
+language: php
 
 php:
   - 5.4


### PR DESCRIPTION
The `language` key expects a string, not an array.