### PR TITLE
Travis: test against PHP 7.4, not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ php:
   - 7.0
   - 7.1
   - 7.3
-  - "7.4snapshot"
+  - 7.4
+  - "nightly"
 
 env:
   # Highest supported PHPCS + WPCS versions.
@@ -56,6 +57,10 @@ jobs:
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 7.2
       env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-develop"
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 before_install:
   # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
Looks like Travis (finally) has got a "normal" PHP 7.4 image available.

While we're at it, let's add a build against `nightly` (PHP 8) back which is allowed to fail.