### PR TITLE
Update suggested version of Composer PHPCS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you use Composer to manage dependencies from your project anyway or are consi
 From the command-line, run the following command from the root directory of your project:
 
 ```bash
-$ php composer.phar require --dev wptrt/wpthemereview:* dealerdirect/phpcodesniffer-composer-installer:^0.5.0
+$ php composer.phar require --dev wptrt/wpthemereview:* dealerdirect/phpcodesniffer-composer-installer:^0.6
 ```
 
 > Note:

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,10 @@
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"roave/security-advisories"         : "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6"
 	},
 	"suggest"    : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
 	},
 	"scripts"    : {
 		"install-standards": [


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.6.0`.
As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-