### PR TITLE
Travis/QA: always check that all sniffs are feature complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,11 @@ jobs:
         # Check the code-style consistency of the xml files.
         - diff -B --tabsize=4 ./WPThemeReview/ruleset.xml <(xmllint --format "./WPThemeReview/ruleset.xml")
 
+        # Check that the sniffs available are feature complete.
+        # For now, just check that all sniffs have unit tests.
+        # At a later stage the documentation check can be activated.
+        - composer check-complete
+
     # Seperate test builds for PHP 7.2 with reversed PHPCS vs WPCS branches.
     - stage: test
       php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"roave/security-advisories"         : "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+		"phpcsstandards/phpcsdevtools"      : "^1.0"
 	},
 	"suggest"    : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -66,6 +67,12 @@
 		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"check-complete": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./WPThemeReview"
+		],
+		"check-complete-strict": [
+			"@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./WPThemeReview"
 		]
 	},
 	"support"    : {


### PR DESCRIPTION
The new `phpcsstandards/phpcsdevtools` package includes a script which can check whether sniffs are feature complete, i.e. whether all sniffs have unit tests and documentation.

By adding this check to the Travis script, we prevent untested and/or undocumented sniffs from entering the repo.

For now, the documentation check is silenced.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools#checking-whether-all-sniffs-in-a-phpcs-standard-are-feature-complete

P.S.: the `PHPCSDevTools` package contains a few more goodies, have a look at the [readme](https://github.com/PHPCSStandards/PHPCSDevTools) for more information.