### PR TITLE
Add allow failures for WPCS dev-develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ before_install:
 
 install:
   - if [[ ${WPCS_BRANCH} == "dev-develop" ]]; then travis_retry composer config minimum-stability dev; fi
-  - travis_retry composer install --dev --no-suggest
+  - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
+  - travis_retry composer install --no-suggest
 
 script:
   # Lint the PHP files against parse errors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,14 +88,19 @@ install:
     if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
       travis_retry composer install --dev --no-suggest
       # The Composer PHPCS plugin takes care of the installed_paths.
-    elif [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
+    else
+      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then travis_retry composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
+      travis_retry composer install --no-dev --no-suggest --no-scripts
+      travis_retry composer install-standards
+    fi
+  - |
+    if [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
       # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 7.x to install on nightly.
       travis_retry composer install --ignore-platform-reqs --no-suggest
     else
-      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
-      travis_retry composer install --no-dev --no-suggest --no-scripts
-      travis_retry composer install-standards
+      # Do a normal dev install in all other cases.
+      travis_retry composer install --no-suggest
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ cache:
 language: php
 
 php:
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -64,6 +66,15 @@ jobs:
     - php: 7.4
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop"
 
+    # Builds which need a different distribution.
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
+
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
@@ -83,25 +94,8 @@ before_install:
   - export XMLLINT_INDENT="	"
 
 install:
-  - travis_retry composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
-  - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
-      travis_retry composer install --dev --no-suggest
-      # The Composer PHPCS plugin takes care of the installed_paths.
-    else
-      if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then travis_retry composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
-      travis_retry composer install --no-dev --no-suggest --no-scripts
-      travis_retry composer install-standards
-    fi
-  - |
-    if [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
-      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
-      # requirements to get PHPUnit 7.x to install on nightly.
-      travis_retry composer install --ignore-platform-reqs --no-suggest
-    else
-      # Do a normal dev install in all other cases.
-      travis_retry composer install --no-suggest
-    fi
+  - if [[ ${WPCS_BRANCH} == "dev-develop" ]]; then travis_retry composer config minimum-stability dev; fi
+  - travis_retry composer install --dev --no-suggest
 
 script:
   # Lint the PHP files against parse errors.
@@ -112,9 +106,4 @@ script:
   - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all --strict; fi
 
   # Run the unit tests.
-  - |
-    if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-      vendor/bin/phpunit --filter WPThemeReview $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
-    else
-      phpunit --filter WPThemeReview $(pwd)/vendor/squizlabs/php_codesniffer/tests/AllTests.php
-    fi
+  - composer run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop" LINT=1
   # Lowest supported PHPCS + WPCS versions.
   - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.2.0"
+  # Highest supported PHPCS + stable WPCS version.
+  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" LINT=1
 
 stages:
   - sniff
@@ -61,11 +63,13 @@ jobs:
       php: 7.2
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 7.2
-      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-develop"
+      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-master"
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
+    - env: WPCS_BRANCH="dev-develop"
+
 
 before_install:
   # Speed up build time by disabling Xdebug.
@@ -74,7 +78,7 @@ before_install:
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
   - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS_BRANCH != "dev-develop" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS_BRANCH != "dev-master" ]]; then
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+os: linux
+dist: xenial
 
 cache:
   apt: true
@@ -11,8 +12,6 @@ cache:
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -22,11 +21,9 @@ php:
 
 env:
   # Highest supported PHPCS + WPCS versions.
-  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop" LINT=1
+  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" LINT=1
   # Lowest supported PHPCS + WPCS versions.
   - PHPCS_BRANCH="3.3.1" WPCS_BRANCH="2.2.0"
-  # Highest supported PHPCS + stable WPCS version.
-  - PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-master" LINT=1
 
 stages:
   - sniff
@@ -64,12 +61,13 @@ jobs:
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 7.2
       env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-master"
+    - php: 7.4
+      env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop"
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
-    - env: WPCS_BRANCH="dev-develop"
-
+    - env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="dev-develop"
 
 before_install:
   # Speed up build time by disabling Xdebug.
@@ -78,20 +76,26 @@ before_install:
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
   - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS_BRANCH != "dev-master" ]]; then
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_BRANCH != "dev-master" && $WPCS_BRANCH != "dev-develop" ]]; then
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
   - export XMLLINT_INDENT="	"
-  - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
+
+install:
+  - travis_retry composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
   - |
     if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
-      composer install --dev --no-suggest
+      travis_retry composer install --dev --no-suggest
       # The Composer PHPCS plugin takes care of the installed_paths.
+    elif [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
+      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
+      # requirements to get PHPUnit 7.x to install on nightly.
+      travis_retry composer install --ignore-platform-reqs --no-suggest
     else
       if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then composer require phpunit/phpunit:^7.0 --no-update --no-suggest --no-scripts;fi
-      composer install --no-dev --no-suggest --no-scripts
-      composer install-standards
+      travis_retry composer install --no-dev --no-suggest --no-scripts
+      travis_retry composer install-standards
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,13 +70,13 @@ jobs:
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 5.5
       dist: trusty
-      env: PHPCS_BRANCH="3.5.0"
+      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-master"
     - php: 5.4
       dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
     - php: 5.4
       dist: trusty
-      env: PHPCS_BRANCH="3.5.0"
+      env: PHPCS_BRANCH="3.3.1" WPCS_BRANCH="dev-master"
 
   allow_failures:
     # Allow failures for unstable builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,15 @@ jobs:
     - php: 5.5
       dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
+    - php: 5.5
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0"
     - php: 5.4
       dist: trusty
       env: PHPCS_BRANCH="dev-master" WPCS_BRANCH="2.2.0" LINT=1
-
+    - php: 5.4
+      dist: trusty
+      env: PHPCS_BRANCH="3.5.0"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -93,7 +98,7 @@ before_install:
 
 install:
   - if [[ ${WPCS_BRANCH} == "dev-develop" ]]; then travis_retry composer config minimum-stability dev; fi
-  - composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
+  - travis_retry composer require squizlabs/php_codesniffer:${PHPCS_BRANCH} wp-coding-standards/wpcs:${WPCS_BRANCH} --no-update --no-suggest --no-scripts
   - travis_retry composer install --no-suggest
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"require"    : {
-		"php"                      : ">=5.4",
+		"php"                      : "^5.4 || ^7.0",
 		"squizlabs/php_codesniffer": "^3.3.1",
 		"wp-coding-standards/wpcs" : "^2.2.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0"
@@ -46,7 +46,7 @@
 		"phpunit/phpunit"                   : "^4.0 || ^5.0 || ^6.0 || ^7.0",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"roave/security-advisories"         : "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"phpcsstandards/phpcsdevtools"      : "^1.0"
 	},
 	"suggest"    : {


### PR DESCRIPTION
This is an attempt to fix the failing builds based on [comment](https://github.com/WPTT/WPThemeReview/pull/257#issuecomment-694873406).

I'm not an expert with travis, so not 100% sure the `allow_failures` is correct.

The `WPCS_BRANCH` is set to `dev-master` so that it's stable (develop is in the works currently).