### PR TITLE
GH Actions: turn display_errors on

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL, display_errors=On
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,9 +77,9 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_branch }}" != "dev-master" && "${{ matrix.wpcs_branch }}" != "dev-develop" ]]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
           fi
 
       # Setup PHP versions, run checks


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

In the `test` script, error_reporting was already enabled, but the error display was not yet fixed. Sorted now.
In the `lint` script, both were missing.